### PR TITLE
Add entirely random path finding strategy

### DIFF
--- a/config.go
+++ b/config.go
@@ -7,12 +7,17 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+type ConfigPath struct {
+	Attempts int    `yaml:"attempts"`
+	Strategy string `yaml:"strategy"`
+}
+
 type Config struct {
-	Layout   string      `yaml:"layout"`
-	Strategy string      `yaml:"strategy"`
-	Nodes    ConfigNodes `yaml:"nodes"`
-	Edges    ConfigEdges `yaml:"edges"`
-	Spacing  int         `yaml:"-"`
+	Layout  string      `yaml:"layout"`
+	Path    ConfigPath  `yaml:"path"`
+	Nodes   ConfigNodes `yaml:"nodes"`
+	Edges   ConfigEdges `yaml:"edges"`
+	Spacing int         `yaml:"-"`
 
 	NodeWidth  int `yaml:"width"`
 	NodeHeight int `yaml:"height"`
@@ -50,6 +55,10 @@ func NewConfigFromFile(r io.Reader) (*Config, error) {
 		return nil, fmt.Errorf("reading config file: %w", err)
 	}
 	config.Spacing = 20
+
+	if config.Path.Attempts == 0 {
+		config.Path.Attempts = 5
+	}
 
 	if config.NodeWidth == 0 {
 		config.NodeWidth = 5

--- a/config.go
+++ b/config.go
@@ -8,10 +8,11 @@ import (
 )
 
 type Config struct {
-	Layout  string      `yaml:"layout"`
-	Nodes   ConfigNodes `yaml:"nodes"`
-	Edges   ConfigEdges `yaml:"edges"`
-	Spacing int         `yaml:"-"`
+	Layout   string      `yaml:"layout"`
+	Strategy string      `yaml:"strategy"`
+	Nodes    ConfigNodes `yaml:"nodes"`
+	Edges    ConfigEdges `yaml:"edges"`
+	Spacing  int         `yaml:"-"`
 
 	NodeWidth  int `yaml:"width"`
 	NodeHeight int `yaml:"height"`

--- a/go.sum
+++ b/go.sum
@@ -167,6 +167,7 @@ github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn
 github.com/otiai10/copy v1.11.0 h1:OKBD80J/mLBrwnzXqGtFCzprFSGioo30JcmR4APsNwc=
 github.com/otiai10/copy v1.11.0/go.mod h1:rSaLseMUsZFFbsFGc7wCJnnkTAvdc5L6VWxPE4308Ww=
 github.com/otiai10/mint v1.5.1 h1:XaPLeE+9vGbuyEHem1JNk3bYc7KKqyI/na0/mLd/Kks=
+github.com/otiai10/mint v1.5.1/go.mod h1:MJm72SBthJjz8qhefc4z1PYEieWmy8Bku7CjcAqyUSM=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/layli_test.go
+++ b/layli_test.go
@@ -20,6 +20,9 @@ nodes:
 	config, err := NewConfigFromFile(r)
 	require.NoError(t, err)
 	assert.Equal(t, Config{
+		Path: ConfigPath{
+			Attempts: 5,
+		},
 		Nodes: ConfigNodes{
 			ConfigNode{
 				Id:       "node-1",

--- a/layout.go
+++ b/layout.go
@@ -46,7 +46,7 @@ func NewLayoutFromConfig(finder CreateFinder, c *Config) (*Layout, error) {
 		layoutBorder: c.Border,
 	}
 
-	err = pathStrategy(c.Edges, &l.Paths, l.FindPath)
+	err = pathStrategy(*c, &l.Paths, l.FindPath)
 	if err != nil {
 		return nil, err
 	}

--- a/layout.go
+++ b/layout.go
@@ -27,7 +27,11 @@ type Layout struct {
 
 func NewLayoutFromConfig(finder CreateFinder, c *Config) (*Layout, error) {
 	arranger, err := selectArrangement(c)
+	if err != nil {
+		return nil, err
+	}
 
+	pathStrategy, err := selectPathStrategy(c)
 	if err != nil {
 		return nil, err
 	}
@@ -42,11 +46,9 @@ func NewLayoutFromConfig(finder CreateFinder, c *Config) (*Layout, error) {
 		layoutBorder: c.Border,
 	}
 
-	for _, p := range c.Edges {
-		err := l.AddPath(p.From, p.To)
-		if err != nil {
-			return nil, err
-		}
+	err = pathStrategy(c.Edges, &l.Paths, l.FindPath)
+	if err != nil {
+		return nil, err
 	}
 
 	return l, nil

--- a/layout_test.go
+++ b/layout_test.go
@@ -178,6 +178,12 @@ func TestLayout_ErrorsOnBadLayoutName(t *testing.T) {
 
 }
 
+func TestLayout_ErrorsOnBadPathStrategy(t *testing.T) {
+	_, err := NewLayoutFromConfig(func(start, end dijkstra.Point) PathFinder { return nil }, &Config{Path: ConfigPath{Strategy: "unknown"}})
+	require.Error(t, err)
+
+}
+
 func TestLayout_InsideAny(t *testing.T) {
 	finder := mocks.NewPathFinder(t)
 	l, err := NewLayoutFromConfig(func(start, end dijkstra.Point) PathFinder { return finder }, &layoutTestConfig)

--- a/path.go
+++ b/path.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"math/rand"
 
 	"github.com/dnnrly/layli/pathfinder/dijkstra"
 )
@@ -110,7 +111,10 @@ type PathStrategy func(edges ConfigEdges, paths *LayoutPaths, find func(from, to
 func selectPathStrategy(c *Config) (PathStrategy, error) {
 	switch c.Strategy {
 	// Shortest first
-	// Random strategy
+	case "random":
+		return findPathsRandomly, nil
+	case "in-order":
+		fallthrough
 	case "":
 		return findPathsInOrder, nil
 	default:
@@ -128,4 +132,23 @@ func findPathsInOrder(edges ConfigEdges, paths *LayoutPaths, find func(from, to 
 		*paths = append(*paths, *path)
 	}
 	return nil
+}
+
+func findPathsRandomly(edges ConfigEdges, paths *LayoutPaths, find func(from, to string) (*LayoutPath, error)) error {
+	count := 0
+	var err error
+
+	for count < 5 {
+		rand.Shuffle(len(edges), func(i, j int) { edges[i], edges[j] = edges[j], edges[i] })
+		err := findPathsInOrder(edges, paths, find)
+		if err == nil {
+			return nil
+		}
+		if err != dijkstra.ErrNotFound {
+			return err
+		}
+
+	}
+
+	return err
 }

--- a/path_test.go
+++ b/path_test.go
@@ -1,6 +1,10 @@
 package layli
 
 import (
+	"errors"
+	"fmt"
+	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -42,12 +46,12 @@ func TestLayout_AddPath_BetweenAdjacentNodes(t *testing.T) {
 		return finder
 	}, &pathTestConfig)
 
-	require.NoError(t, l.AddPath("1", "2"))
+	path, err := l.FindPath("1", "2")
+	require.NoError(t, err)
 
 	assert.Equal(t, Point{X: 5.5, Y: 5.5}, gotStart)
 	assert.Equal(t, Point{X: 12.5, Y: 5.5}, gotEnd)
 
-	assert.Len(t, l.Paths, 1)
 	assert.Equal(t, LayoutPath{
 		Points: []Point{
 			{X: 5.5, Y: 5.5},
@@ -55,7 +59,7 @@ func TestLayout_AddPath_BetweenAdjacentNodes(t *testing.T) {
 			{X: 12, Y: 5},
 			{X: 12.5, Y: 5.5},
 		},
-	}, l.Paths[0])
+	}, *path)
 }
 
 // func TestLayout_AddPath_ErrorAddingPaths(t *testing.T) {
@@ -120,4 +124,87 @@ func TestLayout_BuildVertexMapWithPaths(t *testing.T) {
 		..xxxxxxxxxxxxxx..
 		..................
 		..................`, "	", ""), vm.String(), vm)
+}
+
+func Test_selectPathStrategy(t *testing.T) {
+	tests := []struct {
+		name    string
+		c       Config
+		want    PathStrategy
+		wantErr bool
+	}{
+		{name: "unknown generates error", c: Config{Strategy: "unknown"}, want: nil, wantErr: true},
+		{name: "defaults to in-order", c: Config{}, want: findPathsInOrder, wantErr: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := selectPathStrategy(&(tt.c))
+			if (err != nil) != tt.wantErr {
+				t.Errorf("selectPathStrategy() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				assert.Equal(t,
+					reflect.ValueOf(tt.want).Pointer(), reflect.ValueOf(got).Pointer(),
+					fmt.Sprintf("expected '%v' but got '%v'",
+						runtime.FuncForPC(reflect.ValueOf(tt.want).Pointer()).Name(),
+						runtime.FuncForPC(reflect.ValueOf(got).Pointer()).Name(),
+					))
+			}
+		})
+	}
+}
+
+func Test_findPathsInOrder_runsInOrder(t *testing.T) {
+	var record []struct {
+		from, to string
+	}
+	paths := LayoutPaths{}
+	err := findPathsInOrder(
+		ConfigEdges{
+			{From: "a", To: "b"},
+			{From: "1", To: "2"},
+			{From: "2", To: "3"},
+			{From: "r", To: "t"},
+		},
+		&paths,
+		func(from, to string) (*LayoutPath, error) {
+			record = append(record, struct {
+				from string
+				to   string
+			}{from: from, to: to})
+			return &LayoutPath{}, nil
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Len(t, paths, 4)
+	assert.Equal(t, []struct {
+		from string
+		to   string
+	}{{from: "a", to: "b"},
+		{from: "1", to: "2"},
+		{from: "2", to: "3"},
+		{from: "r", to: "t"},
+	}, record)
+}
+
+func Test_findPathsInOrder_passesErrorThrough(t *testing.T) {
+	expectedErr := errors.New("an error")
+
+	paths := LayoutPaths{}
+	err := findPathsInOrder(
+		ConfigEdges{
+			{From: "a", To: "b"},
+			{From: "1", To: "2"},
+			{From: "2", To: "3"},
+			{From: "r", To: "t"},
+		},
+		&paths,
+		func(from, to string) (*LayoutPath, error) {
+			return nil, expectedErr
+		},
+	)
+
+	assert.ErrorIs(t, expectedErr, err)
 }

--- a/pathfinder/dijkstra/djikstra.go
+++ b/pathfinder/dijkstra/djikstra.go
@@ -6,6 +6,10 @@ import (
 	"math"
 )
 
+var (
+	ErrNotFound = errors.New("no path found")
+)
+
 type CostFunction func(from, to Point) int64
 
 type PathFinder struct {
@@ -88,7 +92,7 @@ func (pf *PathFinder) BestPath() ([]Point, error) {
 		}
 	}
 
-	return nil, errors.New("no path found")
+	return nil, ErrNotFound
 }
 
 func (pf *PathFinder) reconstructPath(previous map[Point]Point) []Point {

--- a/pathfinder/dijkstra/djikstra_test.go
+++ b/pathfinder/dijkstra/djikstra_test.go
@@ -79,5 +79,5 @@ func TestCannotFindImpossiblePath(t *testing.T) {
 	pf.AddConnection(p(3, 2), cost, p(2, 2))
 
 	_, err := pf.BestPath()
-	assert.Contains(t, err.Error(), "no path found")
+	assert.ErrorIs(t, err, ErrNotFound)
 }

--- a/test/features/cli.feature
+++ b/test/features/cli.feature
@@ -77,6 +77,12 @@ Feature: Simple CLI commands
         And in the SVG file, all nodes fit on the image
 
     @Acceptance
+    Scenario: Arranges paths to prevent blockages
+        When the app runs with parameters "tmp/fixtures/inputs/blocked.layli"
+        Then the app exits without error
+        And a file "tmp/fixtures/inputs/blocked.svg" exists
+
+    @Acceptance
     Scenario: Sets output file correctly
         When the app runs with parameters "--output tmp/another-file.svg tmp/fixtures/inputs/2-nodes.layli"
         Then the app exits without error

--- a/test/fixtures/inputs/blocked.layli
+++ b/test/fixtures/inputs/blocked.layli
@@ -1,0 +1,49 @@
+nodes:
+  - id: node1
+    contents: "Node 1"
+  - id: node2
+    contents: "Node 2"
+  - id: node3
+    contents: "Node 3"
+  - id: node4
+    contents: "Node 4"
+  - id: node5
+    contents: "Node 5"
+  - id: node6
+    contents: "Node 6"
+  - id: node7
+    contents: "Node 7"
+  - id: node8
+    contents: "Node 8"
+  - id: node9
+    contents: "Node 9"
+  - id: node10
+    contents: "Node 10"
+  - id: node11
+    contents: "Node 11"
+  - id: node12
+    contents: "Node 12"
+  - id: node13
+    contents: "Node 13"
+  - id: node14
+    contents: "Node 14"
+
+edges:
+  - from: node1
+    to: node2
+  - from: node2
+    to: node3
+  - from: node3
+    to: node7
+  - from: node7
+    to: node11
+  - from: node11
+    to: node10
+  - from: node10
+    to: node9
+  - from: node9
+    to: node5
+  - from: node5
+    to: node1
+  - from: node6
+    to: node12

--- a/test/fixtures/inputs/blocked.layli
+++ b/test/fixtures/inputs/blocked.layli
@@ -1,3 +1,6 @@
+path:
+  strategy: random
+
 nodes:
   - id: node1
     contents: "Node 1"


### PR DESCRIPTION
# Description

This implements a different strategy for finding paths based on randomly shuffling the order that we try to evaluate paths in

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Running existing tests
- [x] Created new tests

# Checklist:

- [ ] My code has been linted (`make lint`)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have rebased my branch to include the latest changes from `master`
